### PR TITLE
dynamic auth support

### DIFF
--- a/RapidApi/RapidApi.csproj
+++ b/RapidApi/RapidApi.csproj
@@ -17,14 +17,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.3.0" />
     <PackageReference Include="Azure.Storage.Files.Shares" Version="12.5.0" />
     <PackageReference Include="Ductus.FluentDocker" Version="2.7.3" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
 
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.35.0" />
 
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.0" />
+
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.18.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.22.0" />
     <PackageReference Include="Microsoft.OData.Client" Version="7.7.2" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.7.2" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.7.2" />


### PR DESCRIPTION
it is now for users to upload the mock service to their own azure subscriptions. 
They are only required to pass the tenantId and can pass a subscriptionId if they want to use a specific subscription. The subscriptionId is optional. You can pass or not pass it 